### PR TITLE
Add service definition

### DIFF
--- a/Lab02.md
+++ b/Lab02.md
@@ -9,6 +9,7 @@
 
 ```
 kubectl apply -f https://k8s.io/examples/application/deployment.yaml
+kubectl expose deploy nginx-deployment
 kubectl get pods --watch
 ```
 


### PR DESCRIPTION
The `https://k8s.io/examples/application/deployment.yaml` containers only a `kind: Deployment` and no `kind: Service`,  therefore the service has to be created separately.