### PR TITLE
Rename kube-master to node1

### DIFF
--- a/Lab01.md
+++ b/Lab01.md
@@ -34,7 +34,7 @@ Boot drives are formatted with an file system while storage drives are unallocat
                                      |                    |
 +----------------------+   SSH       |                 +--v-----------------------+
 |                      +-------------+                 |                          |
-| Lab Master           |                               | lab05-k8s-master-1       |
+| Lab Master           |                               | node1                    |
 | Terraform            |                               | Kubernetes master+worker |
 | shared by students   |                               | login: root              |
 | login: labXX         +---v                           | student dedicated        |
@@ -42,7 +42,7 @@ Boot drives are formatted with an file system while storage drives are unallocat
                            |
                            |                           +----------------------+
                            |                           |                      |
-                           |                           | lab05-k8s-node-1     |
+                           |                           | node2                |
                            |                           | Kubernetes worker    |
                            +-------------------------->+ login: root          |
                                     SSH                | student dedicated    |
@@ -62,7 +62,7 @@ ssh <your_lab_username>@<lab_master_server>
 
 Do a quick check that all your assigned host are availabline. These Ansible commands are to be run on the lab master.
 
-### List Lab Hosts 
+### List Lab Hosts
 
 You should have a total of three hosts assigned to you.
 ```

--- a/Lab10.md
+++ b/Lab10.md
@@ -7,7 +7,7 @@
 
 ## Deploying Rook
 
-SSH into the kube-master and deploy the Rook operator.
+SSH into the node1 and deploy the Rook operator.
 
 ```
 kubectl create -f https://raw.githubusercontent.com/rook/rook/release-1.0/cluster/examples/kubernetes/ceph/common.yaml

--- a/setup/templates/ssh_config.j2
+++ b/setup/templates/ssh_config.j2
@@ -1,7 +1,7 @@
-Host kube-master
+Host node1
 	HostName {{ master_ip }}
 	User root
 
-Host kube-worker
+Host node2
 	HostName {{ worker_ip }}
 	User root


### PR DESCRIPTION
As mentioned in https://github.com/packet-labs/Rook-on-Bare-Metal-Workshop/commit/312c04f5c7a3870bb687c1dc9fa60efac3c27883#commitcomment-33500017 renaming to `node1` and `node2` will make things easier from a student's point of view.