### PR TITLE
Specify service name

### DIFF
--- a/Lab02.md
+++ b/Lab02.md
@@ -19,7 +19,7 @@ When the pods are all started, escape the watch command with a ctrl-c.
 ## Verify Networking
 
 ```
-kubectl get services
+kubectl get services nginx-deployment
 curl <CLUSTER_IP>
 ```
 


### PR DESCRIPTION
Adding a service names to make sure only 1 service is returned and avoid potential confusion.