### PR TITLE
Not required to edit the CephCluster manifest

### DIFF
--- a/Lab11.md
+++ b/Lab11.md
@@ -10,22 +10,9 @@
 
 Now that Rook is installed we can go ahead and create a Ceph cluster.
 
-
-Download the sample, reference configuration file for a single node.
-```
-wget https://raw.githubusercontent.com/packet-labs/Rook-on-Bare-Metal-Workshop/master/configs/cluster-master-only.yml
-```
-
-Edit the file:
-* Set the nodes name for your Kubernetes master node
-* Take note of the data directory
-
-Create the data directory for Rook to save data as defined in the config.
-
-
 Start up the single node cluster.
 ```
-kubectl create -f cluster-master-only.yml
+kubectl create -f https://raw.githubusercontent.com/packet-labs/Rook-on-Bare-Metal-Workshop/master/configs/cluster-master-only.yml
 ```
 
 Watch Rook creating pods and initializing your cluster.

--- a/configs/cluster-master-only.yml
+++ b/configs/cluster-master-only.yml
@@ -39,8 +39,6 @@ spec:
 # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
 # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
     nodes:
-    ## LAB TODO - replace the name below with your master node name
-    - name: "##YOUR-MASTER-NODE-NAME-HERE##"
+    - name: node1
       directories: # specific directories to use for storage can be specified for each node
-      ## LAB TODO - make sure the following directory exists on your master node
       - path: "/var/lib/rook"


### PR DESCRIPTION
For all labs the nodes are named `node1` and `node2` we can specify that directly in the manifest.