### PR TITLE
Fix the volume attach error

### DIFF
--- a/setup/templates/inventory.ini.j2
+++ b/setup/templates/inventory.ini.j2
@@ -8,6 +8,9 @@ node1 ansible_host={{ master_ip }} ansible_user=root
 ingress_enabled=true
 ingress_nginx_host_network=true
 
+# Match flexvolume dir with Rook default
+kubelet_flexvolumes_plugins_dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec
+
 ## Other settings
 # Disable StrictHostKeyChecking for all hosts
 ansible_ssh_extra_args='-o StrictHostKeyChecking=no'


### PR DESCRIPTION
Kubespray and Rook have different default path for flexvol dir (See https://github.com/kubernetes-sigs/kubespray/pull/4752), changing it here, so we can continue to use the default Rook `operator.yml`.

Tested in Lab1