### PR TITLE
Fix typo to enable helm

### DIFF
--- a/setup/templates/inventory.ini.j2
+++ b/setup/templates/inventory.ini.j2
@@ -5,7 +5,7 @@ node2 ansible_host={{ worker_ip }} ansible_user=root
 [all:vars]
 ## Kubernetes settings
 # Enable Helm
-helm_enable=True
+helm_enabled=True
 
 # Enable Ingress controller
 ingress_nginx_enabled=True


### PR DESCRIPTION
Helm was not installed because of a typo in the config option that is supposed to enable its install.

Closes #41 
Closes #39 

I have tested this in lab0 ams1