### PR TITLE
Make the hardware types and counts configurable

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -35,6 +35,11 @@ In `labs.ini` you can set a default `packet_facility` option in the `[labs:vars]
 ### Limit to a specific lab
 To (re)setup the lab1 and lab4 use the `--limit` option as follows: `ansible-playbook -i labs.ini  main.yml --limit lab1,lab4`
 
+
+### Customize labs
+
+You can use the `plan_k8s_masters` and `plan_k8s_nodes` to select a different hardware type for the Kubernetes masters and nodes. The `number_of_k8s_masters` and `number_of_k8s_nodes` options allow you to configure lab cluster size.
+
 ### Destroy labs
 
 :warning: this will run a `terraform destroy` and will delete all data in the labs.

--- a/setup/defaults/main.yml
+++ b/setup/defaults/main.yml
@@ -2,3 +2,9 @@ kubespray_version: release-2.11
 terraform_version: 0.12.9
 
 lab_password: "$6$uX6Ohn0iShiZiT5n$GVHs.n8SA/JqRS0THcQ0WxRBbVQTR85DlF/DLKXKfYrMpH82HC6OruqeSfDkAA32X71LycO9XWpfvk0GZZfKJ."
+
+number_of_k8s_masters: 1
+plan_k8s_masters: t1.small.x86
+
+number_of_k8s_nodes: 1
+plan_k8s_nodes: c2.medium.x86

--- a/setup/defaults/main.yml
+++ b/setup/defaults/main.yml
@@ -6,5 +6,7 @@ lab_password: "$6$uX6Ohn0iShiZiT5n$GVHs.n8SA/JqRS0THcQ0WxRBbVQTR85DlF/DLKXKfYrMp
 number_of_k8s_masters: 1
 plan_k8s_masters: t1.small.x86
 
+# s1.large.x86 and c2.medium.x86 have a spare SSD and are acceptable as a node
+# s1.large.x86 is available at more facilities so it is a better default
 number_of_k8s_nodes: 1
-plan_k8s_nodes: c2.medium.x86
+plan_k8s_nodes: s1.large.x86

--- a/setup/defaults/main.yml
+++ b/setup/defaults/main.yml
@@ -6,7 +6,5 @@ lab_password: "$6$uX6Ohn0iShiZiT5n$GVHs.n8SA/JqRS0THcQ0WxRBbVQTR85DlF/DLKXKfYrMp
 number_of_k8s_masters: 1
 plan_k8s_masters: t1.small.x86
 
-# s1.large.x86 and c2.medium.x86 have a spare SSD and are acceptable as a node
-# s1.large.x86 is available at more facilities so it is a better default
 number_of_k8s_nodes: 1
-plan_k8s_nodes: s1.large.x86
+plan_k8s_nodes: c2.medium.x86

--- a/setup/templates/cluster.tfvars.j2
+++ b/setup/templates/cluster.tfvars.j2
@@ -13,11 +13,11 @@ public_key_path = "/home/{{ lab_name }}/.ssh/id_rsa.pub"
 facility = "{{ packet_facility }}"
 
 # masters
-number_of_k8s_masters = 1
+number_of_k8s_masters = {{ number_of_k8s_masters }}
 
-plan_k8s_masters = "t1.small.x86"
+plan_k8s_masters = "{{ plan_k8s_masters }}"
 
 # nodes
-number_of_k8s_nodes = 1
+number_of_k8s_nodes = {{ number_of_k8s_nodes }}
 
-plan_k8s_nodes = "c2.medium.x86"
+plan_k8s_nodes = "{{ plan_k8s_nodes }}"


### PR DESCRIPTION
The `plan_*` vars are useful if you want to run this workshop on another hardware platform (ARM, `s1.large.x86`, to work around HW availability issues, etc...).

The `number_of_k8s_*` vars can be useful if you want to make larger lab environment (to test performance, etc...).