### PR TITLE
Lab11 markdown: fix typo on describing master-only yaml

### DIFF
--- a/Lab11.md
+++ b/Lab11.md
@@ -10,8 +10,8 @@
 Now that Rook is installed we can go ahead and create a Ceph cluster.
 
 Take a look at the ["master-only" cluster configuration](configs/cluster-master-only.yml). Take note of:
-* spec.storage.node.names
-* spec.storage.node.names.path
+* spec.storage.nodes.name
+* spec.storage.nodes.name.path
 
 Start up the single node cluster using this configuration file. This will configure a small cluster using the single node and the single data directory.
 ```


### PR DESCRIPTION
Trivial fix for typos