### PR TITLE
M1.xlarge.x86

### DIFF
--- a/Lab01.md
+++ b/Lab01.md
@@ -21,7 +21,7 @@ Kubernetes environment, and the Rook/Ceph management interface.
 | Node     | CPU cores      | Memory (GB) | Boot (GB SSD) | Storage (GB SSD) | Details
 |----------|----------------|-------------|---------------|------------------|---------
 | Master   | 4 x 2.4 GHz    | 8 GB        | 1 x 80        | None             |[t1.small.x86](https://www.packet.com/cloud/servers/t1-small/)
-| Node     | 24 x 2.2 GHz   | 64 GB       | 2 x 120       | 2 x 480          |[c2.medium.x86](https://www.packet.com/cloud/servers/c2-medium-epyc/)
+| Node     | 24 x 2.2 GHz   | 256 GB      | 2 x 480       | 4 x 480          |[m1.xlarge.x86](https://www.packet.com/cloud/servers/m1-xlarge/)
 
 
 Boot drives are formatted with a file system while storage drives are unallocated and available as raw devices.

--- a/setup/defaults/main.yml
+++ b/setup/defaults/main.yml
@@ -7,4 +7,4 @@ number_of_k8s_masters: 1
 plan_k8s_masters: t1.small.x86
 
 number_of_k8s_nodes: 1
-plan_k8s_nodes: c2.medium.x86
+plan_k8s_nodes: m1.xlarge.x86

--- a/setup/labs.ini.sample
+++ b/setup/labs.ini.sample
@@ -1,11 +1,11 @@
 [labs:vars]
 # Set defaults for all labs
 terraform_state=present
-packet_facility=ams1
+packet_facility=ewr1
 
 # Parent group
 [labs]
-lab0 packet_facility=ams1
+#lab0 packet_facility=ams1
 #lab1
 #lab2
 #lab3
@@ -17,7 +17,7 @@ lab0 packet_facility=ams1
 #lab101
 
 [labs-ewr1]
-#lab200
+lab200
 #lab201
 
 [labs-sjc1]
@@ -27,10 +27,6 @@ lab0 packet_facility=ams1
 [labs-nrt1]
 #lab400
 #lab401
-
-[labs-dfw2]
-#lab500
-#lab501
 
 # Group configs
 [labs-ewr1:vars]
@@ -45,12 +41,8 @@ packet_facility=sjc1
 [labs-nrt1:vars]
 packet_facility=nrt1
 
-[labs-dfw2:vars]
-packet_facility=dfw2
-
 [labs:children]
 labs-ams1
 labs-ewr1
 labs-sjc1
 labs-nrt1
-labs-dfw2


### PR DESCRIPTION
The m1.xlarge.x86 has more drives making for a better demo experience when using Ceph since more OSDs are run rather than the c2.medium. I've updated the defaults as well as the lab instructions. 

I also removed dfw2 from the default since it doesn't have the t1.small.